### PR TITLE
Light Curve File Collection Functionality

### DIFF
--- a/src/tess_sip/tess_sip.py
+++ b/src/tess_sip/tess_sip.py
@@ -44,7 +44,7 @@ def SIP(
     aperture_threshold=3,
     sff=False,
     sff_kwargs={},
-    custom_periods=None,
+    given_periods=None,
 ):
     """
     Systematics-insensitive periodogram for finding periods in long period NASA's TESS data.
@@ -83,8 +83,8 @@ def SIP(
         When True, will run SFF detrending.
     sff_kwargs : dict
         Dictionary of SFF key words to pass. See lightkurve's SFFCorrector.
-    custom_periods : None or numpy.ndarray
-        A list of specifically defined periods for the periodogram. If this
+    given_periods : None or numpy.ndarray
+        A list of specific periods to use when evaluating the periodogram. If this
         parameter is not None, then the parameters min_period, max_period, and
         nperiods will be ignored.
 
@@ -259,8 +259,8 @@ def SIP(
     mask = ~(lc - mod * lc.flux.unit).remove_outliers(return_mask=True, sigma=sigma)[1]
     # Loop over some periods we care about
     periods = 1 / np.linspace(1 / min_period, 1 / max_period, nperiods)
-    if custom_periods is not None:
-        periods = np.copy(custom_periods)
+    if given_periods is not None:
+        periods = np.copy(given_periods)
     ws = np.zeros((len(periods), dm.X.shape[1]))
     ws_err = np.zeros((len(periods), dm.X.shape[1]))
     ws_bkg = np.zeros((len(periods), dm.X.shape[1]))

--- a/src/tess_sip/tess_sip.py
+++ b/src/tess_sip/tess_sip.py
@@ -44,6 +44,7 @@ def SIP(
     aperture_threshold=3,
     sff=False,
     sff_kwargs={},
+    custom_periods=None,
 ):
     """
     Systematics-insensitive periodogram for finding periods in long period NASA's TESS data.
@@ -82,6 +83,10 @@ def SIP(
         When True, will run SFF detrending.
     sff_kwargs : dict
         Dictionary of SFF key words to pass. See lightkurve's SFFCorrector.
+    custom_periods : None or numpy.ndarray
+        A list of specifically defined periods for the periodogram. If this
+        parameter is not None, then the parameters min_period, max_period, and
+        nperiods will be ignored.
 
     Returns
     -------
@@ -249,6 +254,8 @@ def SIP(
 
     # Loop over some periods we care about
     periods = 1 / np.linspace(1 / min_period, 1 / max_period, nperiods)
+    if custom_periods is not None:
+        periods = np.copy(custom_periods)
     ws = np.zeros((len(periods), dm.X.shape[1]))
     ws_err = np.zeros((len(periods), dm.X.shape[1]))
     ws_bkg = np.zeros((len(periods), dm.X.shape[1]))

--- a/src/tess_sip/tess_sip.py
+++ b/src/tess_sip/tess_sip.py
@@ -99,6 +99,7 @@ def SIP(
             period_at_max_power: the best fit period of the sinusoid.
             power_bkg: the power at each period for the pixels -outside- the aperture
             raw_lc_bkg: the background light curve (pixels outside aperture)
+            model: the systematics model used to correct the light curve
     """
 
     if ((type(tpfs) is lk.collections.TargetPixelFileCollection) or 
@@ -284,6 +285,7 @@ def SIP(
         "raw_lc_bkg": lc_bkg,
         "corr_lc": lc - mod * lc.flux.unit + 1 * lc.flux.unit,
         "period_at_max_power": periods[am],
+        "model": mod * lc.flux.unit,
     }
 
     return r


### PR DESCRIPTION
Most of the changes are related to a new ability to use a collection of light curve files as an alternative to inputting a collection of target pixel files. The results are comparable to using the target pixel files, but the target pixel file input is still preferred. Other modifications include an added input for specific periods to search in the periodogram and the model used to correct the raw lightcurve is available as an output.

Light Curve Files:
![TIC288735205_SIP_lcf](https://user-images.githubusercontent.com/30506178/117527128-747cad00-af7e-11eb-8e27-f28fbaa05826.png)

Target Pixel Files:
![TIC288735205_SIP_tpf](https://user-images.githubusercontent.com/30506178/117527123-6cbd0880-af7e-11eb-900f-401f3a8f023d.png)
